### PR TITLE
conn-184 -- add notification dates schema

### DIFF
--- a/commons/active/connect/NotificationDates.avsc
+++ b/commons/active/connect/NotificationDates.avsc
@@ -1,0 +1,17 @@
+{
+  "namespace": "org.radarcns.active.connect",
+  "type": "record",
+  "name": "NotificationDates",
+  "doc": "Notification schedule dates",
+  "fields": [
+    { "name": "time", "type": "double", "doc": "Timestamp in UTC (s) when the notifications are scheduled." },
+    { "name": "scheduledDates", "type": {
+        "type": "array",
+          "items": {
+                "name": "scheduledDate",
+                "type": "double",
+                "doc": "scheduled date"
+            }
+    }, "doc": "Schedule dates."}
+  ]
+}

--- a/commons/active/connect/NotificationSchedule.avsc
+++ b/commons/active/connect/NotificationSchedule.avsc
@@ -23,7 +23,6 @@
           "items": {
               "name": "ActiveDay",
                 "type": "enum",
-                "name": "weekdays",
                 "symbols": [
                     "MONDAY",
                     "TUESDAY",

--- a/specifications/active/CONNECT-1.0.0.yaml
+++ b/specifications/active/CONNECT-1.0.0.yaml
@@ -41,3 +41,7 @@ data:
     doc: A quantity sample type that measures the environment audio exposure, unit is dBASPL.
     topic: active_apple_healthkit_env_exposure
     value_schema: .active.healthkit.HealthKitTypedData
+  - type: NOTIFICATION_SCHEDULE_DATES_LOG
+    doc: Notification schedule dates log
+    topic: notification_schedule_dates
+    value_schema: .active.connect.NotificationDates


### PR DESCRIPTION
When a local notification is scheduled, sends a log to the server with the time/date the notification was scheduled for